### PR TITLE
[Fix] apigateway uri 지정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 #            postLogger: true
       routes:
         - id: user-service
-          uri: lb://USER-SERVICE
+          uri: http://172.31.10.0:8000
           predicates:
             - Path=/user-service/login
             - Method=POST
@@ -28,7 +28,7 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*),/$\{segment}
         - id: user-service
-          uri: lb://USER-SERVICE
+          uri: http://172.31.10.0:8000
           predicates:
             - Path=/user-service/users
             - Method=POST
@@ -36,7 +36,7 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*),/$\{segment}
         - id: user-service
-          uri: lb://USER-SERVICE
+          uri: http://172.31.10.0:8000
           predicates:
             - Path=/user-service/**
             - Method=GET


### PR DESCRIPTION
### ✏️ 작업 개요
apigateway uri 지정

### ⛳ 작업 분류
- [x] 기존 디스커버리로 찾던 uri를 지정

### 🔨 작업 상세 내용
1. 계속 게이트웨이에서 해당 docker dns 조회가 불가능하여 로그들을 보니 도커 네트워크 설정이 되어 있지 않았습니다. 현재 두 개의 서버가 물리적으로 다르기에 이것을 어떻게 처리할지 고민하다 일단은 uri를 강제로 지정하게 하였습니다.

### 💡 생각해볼 문제
- 냉무